### PR TITLE
GitHub Actions経由でDocker Hubにイメージをプッシュする

### DIFF
--- a/.github/workflows/push-docker-image.yaml
+++ b/.github/workflows/push-docker-image.yaml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - develop
-      - push-docker-image-to-docker-hub # デバッグ用に追加
+      - main
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
## 概要

- GitHub Actions経由でDocker Hubにイメージをプッシュできるようにします
- プッシュしたイメージを使ってECSにコンテナをデプロイし、アプリケーション・サーバーを提供する予定です

## 成功したログ

- https://github.com/taniiicom/sharepods/actions/runs/11529468547/job/32097906276?pr=4
- https://hub.docker.com/layers/plass/sharepods-backend/push-docker-image-to-docker-hub/images/sha256-cc19a8eba4c19d3ef576b910a01171c641eda2758db26f6222b812c03c34d3c5?context=repo