### PR TITLE
CORS用のヘッダーを返す

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -18,6 +18,7 @@ func main() {
 	e.Use(middleware.Logger())
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOriginFunc: func(origin string) (bool, error) {
+			// 本来ならちゃんとoriginを見るべきだが、ハッカソンなので必ずtrueを返すようにする
 			return true, nil
 		},
 		AllowHeaders:     []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept},

--- a/backend/main.go
+++ b/backend/main.go
@@ -16,6 +16,13 @@ func main() {
 
 	e.Debug = true
 	e.Use(middleware.Logger())
+	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+		AllowOriginFunc: func(origin string) (bool, error) {
+			return true, nil
+		},
+		AllowHeaders:     []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept},
+		AllowCredentials: false,
+	}))
 
 	databaseURL, ok := config.DatabaseURL()
 	if !ok {


### PR DESCRIPTION
## 概要

[オリジン間リソース共有 (CORS) - HTTP | MDN](https://developer.mozilla.org/ja/docs/Web/HTTP/CORS) で必要となるヘッダーを返すようにします

これがないとJavaScriptのXHRからアクセスすることができません